### PR TITLE
Create pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,61 @@
+## Pull Request submission 
+
+*Insert detailed bullet points about your changes here!*
+
+*Insert any instructions to help the reviewer, e.g. "install new requirements from `requirements.txt`"*
+
+#### Code
+
+- [ ] **Requirements** My/our code matches the requirements of the ticket
+- [ ] **Functionality**: New functions meet requirements in issue ticket
+- [ ] **Compliant Code** Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
+- [ ] **Clean Code** 
+    - [ ] Code has been linted
+    - [ ] Code adheres to [DRY]([url](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)) 
+
+#### Documentation
+
+Any new code includes all the following forms of documentation:
+
+- [ ] **Function Documentation** Docstrings within the function(s') definition(s) have been created
+    - [ ] Includes `parameters` and `returns` for all major functions 
+    - [ ] Includes data types
+- [ ] **Updated Documentation**: Documentation has been updated _or a new ticket to do so has been created_
+
+
+#### Testing
+- [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_
+
+---
+
+## Peer Review
+
+- [ ] All requirements install from (updated) `requirements.txt`
+- [ ] Documentation has been created and is clear
+- [ ] Doctrings has been created and accurately describes the function's functionality
+- [ ] Unit tests pass, or if not present _a new ticket to create tests has been created_
+
+
+#### Final approval (post-review)
+
+The author has responded to my review and made changes to my satisfaction.
+- [ ] **I recommend merging this request.**
+
+---
+
+### Review comments
+
+*Insert detailed comments here!*
+
+These might include, but not exclusively:
+
+- bugs that need fixing (does it work as expected? and does it work with other code
+  that it is likely to interact with?)
+- alternative methods (could it be written more efficiently or with more clarity?)
+- documentation improvements (does the documentation reflect how the code actually works?)
+- additional tests that should be implemented (do the tests effectively assure that it
+  works correctly?)
+- code style improvements (could the code be written more clearly?)
+
+Your suggestions should be tailored to the code that you are reviewing.
+Be critical and clear, but not mean. Ask questions and set actions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,21 @@
 
 *Insert any instructions to help the reviewer, e.g. "install new requirements from `requirements.txt`"*
 
+*Let the reviewer know what data files are needed (to be grabbed from sync)
+
+#### Closes or fixes
+
+Fixes #
+
+
 #### Code
 
 - [ ] **Requirements** My/our code matches the requirements of the ticket
 - [ ] **Functionality**: New functions meet requirements in issue ticket
 - [ ] **Compliant Code** Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
+- [ ] **Code runs** The code runs on my machine
 - [ ] **Clean Code** 
-    - [ ] Code has been linted
+    - [ ] Code has been linted (use your favourite linter)
     - [ ] Code adheres to [DRY]([url](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)) 
 
 #### Documentation
@@ -20,21 +28,23 @@ Any new code includes all the following forms of documentation:
 - [ ] **Function Documentation** Docstrings within the function(s') definition(s) have been created
     - [ ] Includes `parameters` and `returns` for all major functions 
     - [ ] Includes data types
-- [ ] **Updated Documentation**: Documentation has been updated _or a new ticket to do so has been created_
+- [ ] **Updated Documentation**: Working doc has been updated and a new ticket to update the master documentation has been created. 
 
+#### Data
+- [ ] All data needed to run this script has been added to Sync
 
 #### Testing
 - [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_
 
 ---
 
-## Peer Review
+# Peer Review Section
 
 - [ ] All requirements install from (updated) `requirements.txt`
-- [ ] Documentation has been created and is clear
-- [ ] Doctrings has been created and accurately describes the function's functionality
+- [ ] Documentation has been created and is clear - check the google Doc
+- [ ] Doctrings ([Google format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)) have been created and accurately describe the function's functionality
 - [ ] Unit tests pass, or if not present _a new ticket to create tests has been created_
-
+- [ ] **Code runs** The code runs on reviewer's machine
 
 #### Final approval (post-review)
 


### PR DESCRIPTION
This isn't linked to an issue. 

This PR should create a markdown template that will automatically appear in the first comment in each pull request that is made - which should help both the developer submitting the PR and the reviewer.

Template is adapted from: https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html