### PR TITLE
Creating and exporting highly serviced bus stops

### DIFF
--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -161,9 +161,16 @@ bus_timetable_df = bus_timetable_df.drop(columns=['trip_id', 'route_id']) # 'ser
 # ----------------------------
 
 # Only interested in stops that are used on a certain day
-serviced_bus_stops_df = bus_timetable_df[bus_timetable_df[timetable_day] == 1]
-#serviced_bus_stops = dt.filter_bus_timetable_by_day(bus_timetable_df, timetable_day.capitalize())
 
+day_filter_type = config["day_filter"]
+if day_filter_type == "general":
+    timetable_day = timetable_day.lower()
+    serviced_bus_stops_df = bus_timetable_df[bus_timetable_df[timetable_day] == 1]
+elif day_filter_type == "exact":
+    timetable_day = timetable_day.capitalize()
+    serviced_bus_stops = dt.filter_bus_timetable_by_day(bus_timetable_df, timetable_day.capitalize())
+else:
+    print("Error: input error on day filter setting.")
 
 # -----------------------
 # Find frequency of stops

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -26,7 +26,7 @@ zip_path = os.path.join(output_directory, bus_dataset_name)
 required_files = ['stop_times', 'trips', 'calendar']
 auto_download_bus = config["auto_download_bus"]
 timetable_day = config["timetable_day"]
-
+day_filter_type = config["day_filter"]
 
 # Calculate if bus timetable needs to be downloaded.
 # If current folder doesnt exist, or hasnt been modified then
@@ -162,7 +162,6 @@ bus_timetable_df = bus_timetable_df.drop(columns=['trip_id', 'route_id']) # 'ser
 
 # Only interested in stops that are used on a certain day
 
-day_filter_type = config["day_filter"]
 if day_filter_type == "general":
     timetable_day = timetable_day.lower()
     serviced_bus_stops_df = bus_timetable_df[bus_timetable_df[timetable_day] == 1]

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -48,8 +48,6 @@ else:
 # Note downloads if flag above, and flag in config, set as True.
 # Using individual data ingest functions (rather than import_extract_delete_zip)
 # as files are .txt not .csv.
-download_bus_timetable=True
-auto_download_bus=True
 if download_bus_timetable and auto_download_bus:
     di._grab_zip(file_nm=bus_dataset_name,
                 zip_link=bus_timetable_zip_link,

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -193,6 +193,9 @@ highly_serviced_bus_stops_df = highly_serviced_bus_stops_df.merge(stops_df,
                                                           left_on='stop_id',
                                                           right_on='ATCOCode')
 
+# Remove stops that dont have coordinates
+highly_serviced_bus_stops_df = highly_serviced_bus_stops_df.dropna(subset=['easting', 'northing'], how='any')
+
 # Only keep required columns
 highly_serviced_bus_stops_df = highly_serviced_bus_stops_df[list(config["NAPTAN_TYPES"].keys())]
 

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -123,6 +123,9 @@ else:
 # Clean data
 # ----------
 
+# TODELETE
+# CReate sample for testing
+stop_times_df = stop_times_df.sample(n=1000000)
 # Some departure times are > 24:00 so need to be removed.
 # This is done automatically by restricting times to hours used
 # to define highly serviced stops
@@ -155,7 +158,7 @@ bus_timetable_df = bus_timetable_df.drop(columns=['trip_id', 'route_id']) # 'ser
 
 # Only interested in stops that are used on a certain day
 serviced_bus_stops_df = bus_timetable_df[bus_timetable_df[timetable_day] == 1]
-#serviced_bus_stops_df = dt.filter_bus_timetable_by_day(bus_timetable_df, "Wednesday")
+#serviced_bus_stops = dt.filter_bus_timetable_by_day(bus_timetable_df, timetable_day.capitalize())
 
 
 # -----------------------
@@ -178,7 +181,7 @@ bus_frequencies_df = pd.pivot_table(data=serviced_bus_stops_df,
 # -----------------------------
 
 # Only keep those which have at least one service an hour
-highly_serviced_stops_df = bus_frequencies_df[bus_frequencies_df.all(1)]
+highly_serviced_stops_df = bus_frequencies_df[(bus_frequencies_df > 0).all(axis=1)]
 
 # Read in naptan data
 stops_df = di.get_stops_file(url=config["NAPTAN_API"],
@@ -195,3 +198,11 @@ highly_serviced_stops_df = highly_serviced_stops_df[list(config["NAPTAN_TYPES"].
 
 # Save a copy to be ingested by SDG_11.2.1_main
 highly_serviced_stops_df.to_feather(os.path.join(output_directory, 'highly_serviced_stops.feather'))
+
+# TODELETE
+# CReate outputs from sample
+stop_times_df.to_csv(os.path.join(output_directory, 'stop_times_df.csv'))
+bus_timetable_df.to_csv(os.path.join(output_directory, 'bus_timetable_df.csv'))
+serviced_bus_stops_df.to_csv(os.path.join(output_directory, 'serviced_bus_stops_df.csv'))
+bus_frequencies_df.to_csv(os.path.join(output_directory, 'bus_frequencies_df.csv'))
+highly_serviced_stops_df.to_csv(os.path.join(output_directory, 'highly_serviced_stops_df.csv'))

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -25,11 +25,12 @@ output_directory = os.path.join(CWD, 'data', 'england_bus_timetable')
 zip_path = os.path.join(output_directory, bus_dataset_name)
 required_files = ['stop_times', 'trips', 'calendar']
 auto_download_bus = config["auto_download_bus"]
+timetable_day = config["timetable_day"]
 
 
 # Calculate if bus timetable needs to be downloaded.
-# If current folder doesnt exist, or hasnt been modified for
-# 7 days then redownload the zip
+# If current folder doesnt exist, or hasnt been modified then
+# flag to be downloaded
 
 if not di._persistent_exists(output_directory):
     os.makedirs(output_directory)
@@ -44,6 +45,7 @@ else:
 # Download bus timetable data
 # ---------------------------
 
+# Note downloads if flag above, and flag in config, set as True.
 # Using individual data ingest functions (rather than import_extract_delete_zip)
 # as files are .txt not .csv.
 if download_bus_timetable and auto_download_bus:
@@ -90,30 +92,40 @@ else:
                                 dtypes=stop_times_types)
 
 # trips
-trips_types = {'route_id': 'category',
-               'service_id': 'category', 'trip_id': 'category'}
+feath_ = os.path.join(output_directory, "trips.feather")
+if os.path.exists(feath_):
+    trips_df = di._feath_to_df("trips", feath_)
+else:
+    trips_types = {'route_id': 'category',
+                'service_id': 'category', 'trip_id': 'category'}
 
-trips_df = di._csv_to_df(file_nm='trips',
-                         csv_path=os.path.join(output_directory, 'trips.txt'),
-                         dtypes=trips_types)
+    trips_df = di._csv_to_df(file_nm='trips',
+                            csv_path=os.path.join(output_directory, 'trips.txt'),
+                            dtypes=trips_types)
 
 # calendar
 # NOTE: Not adding in saturday and sunday columns for stops because
 # we are only interested in weekday trips for highly serviced stops
-calendar_types = {'service_id': 'category', 'monday': 'int64', 'tuesday': 'int64',
-                  'wednesday': 'int64', 'thursday': 'int64', 'friday': 'int64',
-                  'start_date': 'object', 'end_date': 'object'}
+feath_ = os.path.join(output_directory, "calendar.feather")
+if os.path.exists(feath_):
+    calendar_df = di._feath_to_df("calendar", feath_)
+else:
+    calendar_types = {'service_id': 'category', 'monday': 'int64', 'tuesday': 'int64',
+                    'wednesday': 'int64', 'thursday': 'int64', 'friday': 'int64',
+                    'start_date': 'object', 'end_date': 'object'}
 
-calendar_df = di._csv_to_df(file_nm='calendar',
-                            csv_path=os.path.join(
-                                output_directory, 'calendar.txt'),
-                            dtypes=calendar_types)
+    calendar_df = di._csv_to_df(file_nm='calendar',
+                                csv_path=os.path.join(
+                                    output_directory, 'calendar.txt'),
+                                dtypes=calendar_types)
 
 # ----------
 # Clean data
 # ----------
 
-# Some departure times are > 24:00 so need to be removed
+# Some departure times are > 24:00 so need to be removed.
+# This is done automatically by restricting times to hours used
+# to define highly serviced stops
 hour_range = range(config["early_bus_hour"],config["late_bus_hour"])
 valid_hours = [f'0{i}' if i < 10 else f'{i}' for i in hour_range]
 
@@ -140,8 +152,46 @@ bus_timetable_df = bus_timetable_df.drop(columns=['trip_id', 'route_id']) # 'ser
 # ----------------------------
 # Extract stops for chosen day
 # ----------------------------
-serviced_bus_stops = dt.filter_bus_timetable_by_day(bus_timetable_df, "Wednesday")
+
+# Only interested in stops that are used on a certain day
+serviced_bus_stops_df = bus_timetable_df[bus_timetable_df[timetable_day] == 1]
+#serviced_bus_stops_df = dt.filter_bus_timetable_by_day(bus_timetable_df, "Wednesday")
 
 
-serviced_bus_stops.head()
-# serviced_bus_stops = dt.filter_bus_timetable_by_date(bus_timetable_df, '20220822')
+# -----------------------
+# Find frequency of stops
+# -----------------------
+
+# Take just HH from departure time
+serviced_bus_stops_df['departure_time'] = serviced_bus_stops_df['departure_time'].str.slice(0,2)
+
+bus_frequencies_df = pd.pivot_table(data=serviced_bus_stops_df,
+                                    values=timetable_day,
+                                    index='stop_id',
+                                    columns='departure_time',
+                                    aggfunc=len,
+                                    fill_value=0)
+
+
+# -----------------------------
+# Extract highly serviced stops
+# -----------------------------
+
+# Only keep those which have at least one service an hour
+highly_serviced_stops_df = bus_frequencies_df[bus_frequencies_df.all(1)]
+
+# Read in naptan data
+stops_df = di.get_stops_file(url=config["NAPTAN_API"],
+                             dir=os.path.join(os.getcwd(), "data", "stops"))
+
+# Add easting and northing
+highly_serviced_stops_df = highly_serviced_stops_df.merge(stops_df,
+                                                          how='inner',
+                                                          left_on='stop_id',
+                                                          right_on='ATCOCode')
+
+# Only keep required columns
+highly_serviced_stops_df = highly_serviced_stops_df[list(config["NAPTAN_TYPES"].keys())]
+
+# Save a copy to be ingested by SDG_11.2.1_main
+highly_serviced_stops_df.to_feather(os.path.join(output_directory, 'highly_serviced_stops.feather'))

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -48,6 +48,8 @@ else:
 # Note downloads if flag above, and flag in config, set as True.
 # Using individual data ingest functions (rather than import_extract_delete_zip)
 # as files are .txt not .csv.
+download_bus_timetable=True
+auto_download_bus=True
 if download_bus_timetable and auto_download_bus:
     di._grab_zip(file_nm=bus_dataset_name,
                 zip_link=bus_timetable_zip_link,
@@ -191,7 +193,7 @@ highly_serviced_bus_stops_df = highly_serviced_bus_stops_df.merge(stops_df,
                                                           right_on='ATCOCode')
 
 # Remove stops that dont have coordinates
-highly_serviced_bus_stops_df = highly_serviced_bus_stops_df.dropna(subset=['easting', 'northing'], how='any')
+highly_serviced_bus_stops_df = highly_serviced_bus_stops_df.dropna(subset=['Easting', 'Northing'], how='any')
 
 # Only keep required columns
 highly_serviced_bus_stops_df = highly_serviced_bus_stops_df[list(config["NAPTAN_TYPES"].keys())]

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -181,23 +181,23 @@ bus_frequencies_df = pd.pivot_table(data=serviced_bus_stops_df,
 # -----------------------------
 
 # Only keep those which have at least one service an hour
-highly_serviced_stops_df = bus_frequencies_df[(bus_frequencies_df > 0).all(axis=1)]
+highly_serviced_bus_stops_df = bus_frequencies_df[(bus_frequencies_df > 0).all(axis=1)]
 
 # Read in naptan data
 stops_df = di.get_stops_file(url=config["NAPTAN_API"],
                              dir=os.path.join(os.getcwd(), "data", "stops"))
 
 # Add easting and northing
-highly_serviced_stops_df = highly_serviced_stops_df.merge(stops_df,
+highly_serviced_bus_stops_df = highly_serviced_bus_stops_df.merge(stops_df,
                                                           how='inner',
                                                           left_on='stop_id',
                                                           right_on='ATCOCode')
 
 # Only keep required columns
-highly_serviced_stops_df = highly_serviced_stops_df[list(config["NAPTAN_TYPES"].keys())]
+highly_serviced_bus_stops_df = highly_serviced_bus_stops_df[list(config["NAPTAN_TYPES"].keys())]
 
 # Save a copy to be ingested by SDG_11.2.1_main
-highly_serviced_stops_df.to_feather(os.path.join(output_directory, 'highly_serviced_stops.feather'))
+highly_serviced_bus_stops_df.to_feather(os.path.join(output_directory, 'highly_serviced_stops.feather'))
 
 # TODELETE
 # CReate outputs from sample
@@ -205,4 +205,4 @@ stop_times_df.to_csv(os.path.join(output_directory, 'stop_times_df.csv'))
 bus_timetable_df.to_csv(os.path.join(output_directory, 'bus_timetable_df.csv'))
 serviced_bus_stops_df.to_csv(os.path.join(output_directory, 'serviced_bus_stops_df.csv'))
 bus_frequencies_df.to_csv(os.path.join(output_directory, 'bus_frequencies_df.csv'))
-highly_serviced_stops_df.to_csv(os.path.join(output_directory, 'highly_serviced_stops_df.csv'))
+highly_serviced_bus_stops_df.to_csv(os.path.join(output_directory, 'highly_serviced_bus_stops_df.csv'))

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -200,3 +200,4 @@ highly_serviced_bus_stops_df = highly_serviced_bus_stops_df[list(config["NAPTAN_
 
 # Save a copy to be ingested by SDG_11.2.1_main
 highly_serviced_bus_stops_df.to_feather(os.path.join(output_directory, 'highly_serviced_stops.feather'))
+highly_serviced_bus_stops_df.to_csv(os.path.join(output_directory, 'highly_serviced_stops.csv'), index=False)

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -123,9 +123,6 @@ else:
 # Clean data
 # ----------
 
-# TODELETE
-# CReate sample for testing
-stop_times_df = stop_times_df.sample(n=1000000)
 # Some departure times are > 24:00 so need to be removed.
 # This is done automatically by restricting times to hours used
 # to define highly serviced stops
@@ -201,11 +198,3 @@ highly_serviced_bus_stops_df = highly_serviced_bus_stops_df[list(config["NAPTAN_
 
 # Save a copy to be ingested by SDG_11.2.1_main
 highly_serviced_bus_stops_df.to_feather(os.path.join(output_directory, 'highly_serviced_stops.feather'))
-
-# TODELETE
-# CReate outputs from sample
-stop_times_df.to_csv(os.path.join(output_directory, 'stop_times_df.csv'))
-bus_timetable_df.to_csv(os.path.join(output_directory, 'bus_timetable_df.csv'))
-serviced_bus_stops_df.to_csv(os.path.join(output_directory, 'serviced_bus_stops_df.csv'))
-bus_frequencies_df.to_csv(os.path.join(output_directory, 'bus_frequencies_df.csv'))
-highly_serviced_bus_stops_df.to_csv(os.path.join(output_directory, 'highly_serviced_bus_stops_df.csv'))

--- a/SDG_bus_timetable.py
+++ b/SDG_bus_timetable.py
@@ -32,8 +32,15 @@ timetable_day = config["timetable_day"]
 # If current folder doesnt exist, or hasnt been modified then
 # flag to be downloaded
 
-if not di._persistent_exists(output_directory):
-    os.makedirs(output_directory)
+files_to_check = [f"{file}.txt" for file in required_files]
+paths_to_check = [os.path.join(output_directory, file) for file in files_to_check]
+each_file_checked = [di._persistent_exists(path) for path in paths_to_check]
+
+if not all(each_file_checked):
+    try:
+        os.makedirs(output_directory)
+    except FileExistsError:
+        print(f"Directory {output_directory} already exists")
     download_bus_timetable = True
 else:
     # Find when the last download occured

--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,7 @@ OA_boundaries_csv: 'https://opendata.arcgis.com/datasets/7763a773b61445128ed3251
 NAPT_ZIP_LINK : "http://naptan.app.dft.gov.uk/DataRequest/Naptan.ashx?format=csv"
 NAPTAN_API: "https://naptan.api.dft.gov.uk/v1/access-nodes?dataFormat=CSV"
 NAPTAN_TYPES :
+  ATCOCode: str
   NaptanCode: str
   CommonName: str
   Easting: int32
@@ -39,6 +40,7 @@ early_bus_hour: 06
 late_bus_hour: 20
 high_cap_buffer: 1000
 low_cap_buffer: 500
+timetable_day: 'wednesday'
 
 
 # Ages 

--- a/config.yaml
+++ b/config.yaml
@@ -41,6 +41,7 @@ late_bus_hour: 20
 high_cap_buffer: 1000
 low_cap_buffer: 500
 timetable_day: 'wednesday'
+day_filter: 'general' #exact
 
 
 # Ages 

--- a/config.yaml
+++ b/config.yaml
@@ -35,7 +35,7 @@ NAPTAN_TYPES :
 NI_bus_stops_data: 'https://www.opendatani.gov.uk/dataset/495c6964-e8d2-4bf1-9942-8d950b3a0ceb/resource/29f3f2fd-d131-4b86-8933-42b5b3763763/download/09-05-2022busstop-list.csv'
 NI_train_stops_data: 'https://www.opendatani.gov.uk/dataset/5f27f171-b8aa-4511-983d-6df6e87bbf20/resource/967e32c3-1cc2-4aee-b485-92121a32eb4d/download/nir-rail-stations.csv'
 ENG_bus_timetable_data: 'https://data.bus-data.dft.gov.uk/timetable/download/gtfs-file/all/'
-auto_download_bus: false
+auto_download_bus: true
 early_bus_hour: 06
 late_bus_hour: 20
 high_cap_buffer: 1000

--- a/data_transform.py
+++ b/data_transform.py
@@ -344,11 +344,14 @@ def filter_bus_timetable_by_day(bus_timetable_df, day):
     nth = ord - 1
     date_of_day_entered = day_filtered_dates.iloc[nth].date
 
-    # Filter the bus_timetable_df 
+    # Filter the bus_timetable_df by date range
     bus_timetable_df = bus_timetable_df[(bus_timetable_df['start_date']
                                          <= date_of_day_entered) & 
                                         (bus_timetable_df['end_date']
                                          >= date_of_day_entered)]
+
+    # Then filter to day of interest
+    bus_timetable_df = bus_timetable_df[bus_timetable_df[day.lower()] == 1]
     
     # Print date being used (consider logging instead)
     day_date = date_of_day_entered.date()
@@ -365,33 +368,3 @@ def filter_bus_timetable_by_day(bus_timetable_df, day):
 
 
     return bus_timetable_df
-
-
-def filter_by_year(df, year="2022"):
-    """Filter the timetable_df by year
-    
-    Args:
-        bus_timetable_df (pandas dataframe): df to filter
-        day (str) : day of the week in title case, e.g. "Wednesday"
-    
-    Returns:
-        pd.DataFrame: pandas dataframe filtered by year specified   
-    """
-    # Measure the dataframe
-    original_rows = df.shape[0]
-
-    # Create string of start and end date of given year
-    start_year = f'{year}0101'
-    end_year = f'{year}1231'
-
-    # Create filter condition
-    start_end_date_during_year = ((df['start_date'] >= start_year)
-                                  & (df['start_date'] <= end_year)
-                                  & (df['end_date'] >= start_year)
-                                  & (df['end_date'] <= end_year))
-    # Filter df
-    df = df.loc[start_end_date_during_year]
-    
-    # Print how many rows have been dropped (consider logging instead)
-    print(f"Filtering by year dropped {original_rows-df.shape[0]} rows")
-    return df


### PR DESCRIPTION
Closes #280
Closes #281 

Highly serviced bus stops extracted. `feather` file saved in `england_bus_timetable` on sync. `csv` file saved in `misc - TO DELETE` as not required for the pipeline to run. Also included `bus_samples.xlsx` in `misc - TO DELETE` which creates the stops for a random sample of 1,00,000 records and  checkpoints the data at various stages. I found it useful for QA-ing the process.

**Main changes**

- Time table filter now done by day (stored in config) rather than by specific date
- Given the user the choice of either a simple day filter or a more specific filter for a particular date. 
- Filter by year function removed
- Specific filter by day function kept incase used in the future. 
- Simple filtering for all days, using the day data that comes with the gtfs data.
- Capitalised and lowercase string handling included to cope with potential differences in the config input

