### PR TITLE
324 disability aggregation northern ireland

### DIFF
--- a/SDG_NI.py
+++ b/SDG_NI.py
@@ -194,8 +194,6 @@ for local_auth in ni_auth:
     
     # Disability disaggregation
 
-    # Calculate prop of disabled in each OA of the LA
-
     only_la_pwc_with_pop = dt.disab_disagg(disability_df, only_la_pwc_with_pop)
 
     # find all the pop centroids which are in the la_stops_geo_df
@@ -240,52 +238,8 @@ for local_auth in ni_auth:
     # Output this iteration's df to the dict
     total_df_dict[local_auth] = la_results_df_out
 
-    # # disability disgaregation
-    # Calculating those served and not served by disability
-    disab_cols = ["number_disabled"]
-
-    disab_servd_df = dt.served_proportions_disagg(pop_df=only_la_pwc_with_pop,
-                                                  pop_in_poly_df=pop_in_poly_df,
-                                                  cols_lst=disab_cols)
-
-    # Feeding the results to the reshaper
-    disab_servd_df_out = do.reshape_for_output(disab_servd_df,
-                                               id_col=disab_cols[0],
-                                               local_auth=local_auth,
-                                               id_rename="Disability Status")
-
-    # The disability df is unusual. I think all rows correspond to people with
-    # disabilities only. There is no "not-disabled" status here (I think)
-    disab_servd_df_out.replace(to_replace="number_disabled",
-                               value="Disabled",
-                               inplace=True)
-    # Calculating non-disabled people served and not served
-    non_disab_cols = ["number_non-disabled"]
-
-    non_disab_servd_df = dt.served_proportions_disagg(
-        pop_df=only_la_pwc_with_pop,
-        pop_in_poly_df=pop_in_poly_df,
-        cols_lst=non_disab_cols)
-
-    # Feeding the results to the reshaper
-    non_disab_servd_df_out = do.reshape_for_output(
-        non_disab_servd_df,
-        id_col=disab_cols[0],
-        local_auth=local_auth,
-        id_rename="Disability Status")
-
-    # The disability df is unusual. I think all rows correspond to people with
-    # disabilities only. There is no "not-disabled" status here (I think)
-    non_disab_servd_df_out.replace(to_replace="number_non-disabled",
-                                   value="Non-disabled",
-                                   inplace=True)
-
-    # Concatting non-disabled and disabled dataframes
-    non_disab_disab_servd_df_out = pd.concat(
-        [non_disab_servd_df_out, disab_servd_df_out])
-
-    # Output this local auth's disab df to the dict
-    disab_df_dict[local_auth] = non_disab_disab_servd_df_out
+    # Disability disaggregation - get disability results in disab_df_dict
+    disab_df_dict = dt.disab_dict(only_la_pwc_with_pop, pop_in_poly_df, disab_df_dict, local_auth)
 
 # every single LA
 all_la = pd.concat(total_df_dict.values())

--- a/SDG_scotland.py
+++ b/SDG_scotland.py
@@ -321,53 +321,8 @@ for local_auth in sc_auth:
     # Output this iteration's urb and rur df to the dict
     urb_rur_df_dict[local_auth] = urb_rur_servd_df_out
 
-    # # disability disgaregation
-    # Calculating those served and not served by disability
-    disab_cols = ["number_disabled"]
-
-    disab_servd_df = dt.served_proportions_disagg(pop_df=only_la_pwc_with_pop,
-                                                  pop_in_poly_df=pop_in_poly_df,
-                                                  cols_lst=disab_cols)
-
-    # Feeding the results to the reshaper
-    disab_servd_df_out = do.reshape_for_output(disab_servd_df,
-                                               id_col=disab_cols[0],
-                                               local_auth=local_auth,
-                                               id_rename="Disability Status")
-
-    # The disability df is unusual. I think all rows correspond to people with
-    # disabilities only. There is no "not-disabled" status here (I think)
-    disab_servd_df_out.replace(to_replace="number_disabled",
-                               value="Disabled",
-                               inplace=True)
-    # Calculating non-disabled people served and not served
-    non_disab_cols = ["number_non-disabled"]
-
-    non_disab_servd_df = dt.served_proportions_disagg(
-        pop_df=only_la_pwc_with_pop,
-        pop_in_poly_df=pop_in_poly_df,
-        cols_lst=non_disab_cols)
-
-    # Feeding the results to the reshaper
-    non_disab_servd_df_out = do.reshape_for_output(
-        non_disab_servd_df,
-        id_col=disab_cols[0],
-        local_auth=local_auth,
-        id_rename="Disability Status")
-
-    # The disability df is unusual. I think all rows correspond to people with
-    # disabilities only. There is no "not-disabled" status here (I think)
-    non_disab_servd_df_out.replace(to_replace="number_non-disabled",
-                                   value="Non-disabled",
-                                   inplace=True)
-
-    # Concatting non-disabled and disabled dataframes
-    non_disab_disab_servd_df_out = pd.concat(
-        [non_disab_servd_df_out, disab_servd_df_out])
-
-    # Output this local auth's disab df to the dict
-    disab_df_dict[local_auth] = non_disab_disab_servd_df_out
-
+    # Disability disaggregation - get disability results in disab_df_dict
+    disab_df_dict = dt.disab_dict(only_la_pwc_with_pop, pop_in_poly_df, disab_df_dict, local_auth)
 
 # every single LA
 all_la = pd.concat(total_df_dict.values())

--- a/data_transform.py
+++ b/data_transform.py
@@ -3,6 +3,7 @@ import pandas as pd
 from convertbng.util import convert_bng
 import numpy as np
 from datetime import date, datetime
+import data_output as do
 
 
 def slice_age_df(df: pd.DataFrame, col_nms: List[str]):
@@ -255,13 +256,11 @@ def disab_disagg(disability_df, la_pop_df):
     """Calculates number of people in the population that are classified as
         disabled or not disabled and this is merged onto the local authority
         population dataframe.
-
     Args:
         disability_df (pd.DataFrame): Dataframe that includes disability
                                     estimates for each output area.
         la_pop_df (gpd.GeoDataFrame): GeoPandas Dataframe that includes
                                 output area codes and population estimates.
-
     Returns:
         gpd.GeoDataFrame: GeoPandas Dataframe that includes population
                         estimates, geographical location, and proportion
@@ -321,7 +320,75 @@ def disab_disagg(disability_df, la_pop_df):
     )
     la_pop_df["number_non-disabled"] = la_pop_df["number_non-disabled"].astype(
         int)
+
     return la_pop_df
+
+
+def disab_dict(la_pop_df, pop_in_poly_df, disability_dict, local_auth):
+    """Creates the dataframe including those who are and are not served by public transport
+    and places it into a disability dictionary for each local authority of interest for 
+    the final csv output.
+
+    Args:
+        la_pop_df (gpd.GeoDataFrame): GeoPandas Dataframe that includes
+                                    output area codes and population estimates.
+        pop_in_poly_df (gpd.GeoDataFrame): A geodata frame with the points inside 
+                                            the polygon.
+        disability_dict (dict): Dictionary to store the disability
+                                    dataframe.
+        local_auth (str): The local authority of interest.
+
+    Returns:
+        disab_df_dict (dict): Dictionary with a disability total dataframe for 
+                            unserved and served populations for all given local authorities.
+    """
+    # Calculating those served and not served by disability
+    disab_cols = ["number_disabled"]
+
+    disab_servd_df = served_proportions_disagg(la_pop_df,
+                                                pop_in_poly_df,
+                                                disab_cols)
+
+    # Feeding the results to the reshaper
+    disab_servd_df_out = do.reshape_for_output(disab_servd_df,
+                                               id_col=disab_cols[0],
+                                               local_auth=local_auth,
+                                               id_rename="Disability Status")
+
+    # The disability df is unusual. I think all rows correspond to people with
+    # disabilities only. There is no "not-disabled" status here (I think)
+    disab_servd_df_out.replace(to_replace="number_disabled",
+                               value="Disabled",
+                               inplace=True)
+    # Calculating non-disabled people served and not served
+    non_disab_cols = ["number_non-disabled"]
+
+    non_disab_servd_df = served_proportions_disagg(
+        pop_df=la_pop_df,
+        pop_in_poly_df=pop_in_poly_df,
+        cols_lst=non_disab_cols)
+
+    # Feeding the results to the reshaper
+    non_disab_servd_df_out = do.reshape_for_output(
+        non_disab_servd_df,
+        id_col=disab_cols[0],
+        local_auth=local_auth,
+        id_rename="Disability Status")
+
+    # The disability df is unusual. I think all rows correspond to people with
+    # disabilities only. There is no "not-disabled" status here (I think)
+    non_disab_servd_df_out.replace(to_replace="number_non-disabled",
+                                   value="Non-disabled",
+                                   inplace=True)
+
+    # Concatting non-disabled and disabled dataframes
+    non_disab_disab_servd_df_out = pd.concat(
+        [non_disab_servd_df_out, disab_servd_df_out])
+
+    # Output this local auth's disab df to the dict
+    disability_dict[local_auth] = non_disab_disab_servd_df_out
+
+    return disability_dict
 
 
 def filter_timetable_by_day(timetable_df, day):

--- a/main.py
+++ b/main.py
@@ -160,8 +160,7 @@ if __name__ == "__main__":
     
     # Get output area boundaries
     # OA_df = pd.read_csv(config["OA_boundaries_csv"])
-    
-    # Read disability data for disaggregations later
+        # Read disability data for disaggregations later
     disability_df = pd.read_csv(os.path.join(CWD,
                                             "data", "disability_status",
                                             "nomis_QS303.csv"),
@@ -442,34 +441,9 @@ if __name__ == "__main__":
         sex_df_dict[local_auth] = sex_servd_df_out
     
         # Calculating non-disabled people served and not served
-        non_disab_cols = ["number_non-disabled"]
-    
-        non_disab_servd_df = (
-            dt.served_proportions_disagg(pop_df=eng_wales_la_pop_df,
-                                        pop_in_poly_df=pop_in_poly_df,
-                                        cols_lst=non_disab_cols)
-        )
-    
-        # Feeding the results to the reshaper
-        non_disab_servd_df_out = do.reshape_for_output(
-            non_disab_servd_df,
-            id_col=disab_cols[0],
-            local_auth=local_auth,
-            id_rename="Disability Status")
-    
-        # The disability df is unusual. I think all rows correspond to people with
-        # disabilities only. There is no "not-disabled" status here (I think)
-        non_disab_servd_df_out.replace(to_replace="number_non-disabled",
-                                    value="Non-disabled",
-                                    inplace=True)
-    
-        # Concatting non-disabled and disabled dataframes
-        non_disab_disab_servd_df_out = pd.concat(
-            [non_disab_servd_df_out, disab_servd_df_out])
-    
-        # Output this local auth's disab df to the dict
-        disab_df_dict[local_auth] = non_disab_disab_servd_df_out
-    
+        # Disability disaggregation - get disability results in disab_df_dict
+        disab_df_dict = dt.disab_dict(eng_wales_la_pop_df, pop_in_poly_df, disab_df_dict, local_auth)
+
         # Calculating those served and not served by urban/rural
         urb_col = ["urb_rur_class"]
     


### PR DESCRIPTION
## Pull Request submission 

I have imported the disability dataset for NI and the proportions of disabled/non-disabled people that are being served/unserved are now part of the NI script.

You will require a new data file in Sync: data/disability_status/qs303_ni.csv to run the script.

I also created a new function `disab_dict` (may want to change the name) in `data_transform` to cut out a whole chunk of copied code across all three scripts. It creates the dataframe for those who are served/unserved for each SA and puts it into a dataframe for that local authority/local government district inside the disability dictionary created. This was created to adhere to DRY across all three scripts and will cut down a lot of the process in the main script when we merge.

#### Closes or fixes

Fixes #


#### Code

- [x] **Requirements** My/our code matches the requirements of the ticket
- [x] **Functionality**: New functions meet requirements in issue ticket
- [x] **Compliant Code** Code is as [PEP 8]([url](https://peps.python.org/pep-0008/)) compliant as I can humanly make it
- [x] **Code runs** The code runs on my machine
- [x] **Clean Code** 
    - [ ] Code has been linted (use your favourite linter)
    - [x] Code adheres to [DRY]([url](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself)) 

#### Documentation

Any new code includes all the following forms of documentation:

- [x] **Function Documentation** Docstrings within the function(s') definition(s) have been created
    - [x] Includes `parameters` and `returns` for all major functions 
    - [ ] Includes data types
- [x] **Updated Documentation**: Working doc has been updated and a new ticket to update the master documentation has been created. 

#### Data
- [x] All data needed to run this script has been added to Sync

#### Testing
- [ ] **Unit tests** Unit tests have been created and are passing _or a new ticket to create tests has been created_
